### PR TITLE
Added Beta Support

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
 </head>
 
 <body>
-  <webview id="pcast" partition="persist:pcasts" src="https://play.pocketcasts.com/"></webview>
-  
+  <webview id="pcast" partition="persist:pcasts" src="https://playbeta.pocketcasts.com/"></webview>
+  <!--<webview id="pcast" partition="persist:pcasts" src="https://play.pocketcasts.com/"></webview>-->
   <script src="jquery.js" ></script>
-	<script src="pcasts.js"></script>
+  <script src="pcasts.js"></script>
 </body>
 </html>

--- a/pcasts.js
+++ b/pcasts.js
@@ -36,7 +36,7 @@ chrome.app.runtime.onLaunched.addListener(function () {
             chrome.commands.onCommand.addListener(function(command) {
                 //console.log('Command:', command);
                 if(command == "pause")
-                    webview.executeScript({ code: "if( document.getElementById('players').style.display = 'block') { document.getElementsByClassName('play_pause_button')[0].click() };" });
+                    webview.executeScript({ code: "document.getElementsByClassName('animated-play-button')[0].click();" });
                 if(command == "next")
                     webview.executeScript({ code: "document.getElementsByClassName('skip_forward_button')[0].click();" });
                 if(command == "previous")


### PR DESCRIPTION
Added support for the PocketCast beta website. The URL changed to the beta URL, and then edited media key support to work with the beta redesign changes.
Media key support should be permanent unless further beta changes, but URL will need to revert to main URL once beta is pushed to stable.